### PR TITLE
지역별 관광지 조회 기능 구현 완료

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     INVALID_TRAVELER_STATISTICS(BAD_REQUEST, "유효하지 않은 여행자 통계입니다."),
     INVALID_SPOT_CATEGORY(BAD_REQUEST, "유효하지 않은 관광지 카테고리입니다."),
     INVALID_SPOT_REGION(BAD_REQUEST, "유효하지 않은 관광지 지역입니다."),
+    INVALID_SPOT_TRANSLATION_REGION(BAD_REQUEST, "유효하지 않은 관광지 번역 지역입니다."),
     // 401 Unauthorized
 
     // 403 Forbidden

--- a/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_LANGUAGE_CODE(BAD_REQUEST, "유효하지 않은 언어 코드입니다."),
     INVALID_TRAVELER_STATISTICS(BAD_REQUEST, "유효하지 않은 여행자 통계입니다."),
     INVALID_SPOT_CATEGORY(BAD_REQUEST, "유효하지 않은 관광지 카테고리입니다."),
+    INVALID_SPOT_REGION(BAD_REQUEST, "유효하지 않은 관광지 지역입니다."),
     // 401 Unauthorized
 
     // 403 Forbidden

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/application/SpotService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/application/SpotService.java
@@ -125,12 +125,15 @@ public class SpotService {
     }
 
     @Transactional(readOnly = true)
-    public List<SimpleSpotTranslationResponse> findAllSpotsByRegion(SpotRegion spotRegion, ApiMember apiMember) {
+    public List<SimpleSpotTranslationResponse> findAllSpotsByRegion(String spotRegion, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         LanguageCode languageCode = member.getLanguageCode();
 
+        spotRegion = spotRegion.replace("-", "_").toUpperCase();
+        SpotRegion spotRegionEnum = SpotRegion.valueOf(spotRegion);
+
         List<SpotTranslation> spotTranslations =
-                spotTranslationRepository.findAllBySpot_SpotRegionAndLanguageCode(spotRegion, languageCode);
+                spotTranslationRepository.findAllBySpot_SpotRegionAndLanguageCode(spotRegionEnum, languageCode);
 
         return spotTranslations.stream()
                 .map(spotTranslation -> {

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/Spot.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/Spot.java
@@ -44,6 +44,10 @@ public class Spot extends BaseTimeEntity {
     @NotNull
     private SpotCategory spotCategory; // TODO : 리스트로 만들어야 함. 교집합 카테고리 가능
 
+    @Enumerated(value = EnumType.STRING)
+    @NotNull
+    private SpotRegion spotRegion;
+
     private String imgUrl;
 
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotRegion.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotRegion.java
@@ -1,0 +1,27 @@
+package com.gamgyul_code.halmang_vision.spot.domain;
+
+import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID_SPOT_CATEGORY;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.gamgyul_code.halmang_vision.global.exception.HalmangVisionException;
+
+public enum SpotRegion {
+
+    WESTERN_JEJU_CITY, JEJU_CITY, EASTERN_JEJU_CITY, WESTERN_SEOGWIPO_CITY, SEOGWIPO_CITY, EASTERN_SEOGWIPO_CITY;
+
+    @JsonCreator
+    public static SpotRegion from(String value) {
+        for (SpotRegion spotRegion : SpotRegion.values()) {
+            if (spotRegion.name().equals(value)) {
+                return spotRegion;
+            }
+        }
+        throw new HalmangVisionException(INVALID_SPOT_CATEGORY); //TODO: 커스텀 에러 구현
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotRegion.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotRegion.java
@@ -1,6 +1,6 @@
 package com.gamgyul_code.halmang_vision.spot.domain;
 
-import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID_SPOT_CATEGORY;
+import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID_SPOT_REGION;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -17,7 +17,7 @@ public enum SpotRegion {
                 return spotRegion;
             }
         }
-        throw new HalmangVisionException(INVALID_SPOT_CATEGORY); //TODO: 커스텀 에러 구현
+        throw new HalmangVisionException(INVALID_SPOT_REGION);
     }
 
     @JsonValue

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslation.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslation.java
@@ -39,6 +39,10 @@ public class SpotTranslation extends BaseTimeEntity {
     @NotNull
     private LanguageCode languageCode;
 
+    @Enumerated(value = EnumType.STRING)
+    @NotNull
+    private SpotTranslationRegion spotTranslationRegion;
+
     @NotBlank
     private String summary; //  TODO : xxx 관련 장소 - 로 Enum
 

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRegion.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRegion.java
@@ -1,0 +1,61 @@
+package com.gamgyul_code.halmang_vision.spot.domain;
+
+import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID_SPOT_TRANSLATION_REGION;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.gamgyul_code.halmang_vision.global.exception.HalmangVisionException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SpotTranslationRegion {
+
+    ENG_WESTERN_JEJU_CITY(LanguageCode.ENG, SpotRegion.WESTERN_JEJU_CITY, "Western Jeju City"),
+    ENG_JEJU_CITY(LanguageCode.ENG, SpotRegion.JEJU_CITY, "Jeju City"),
+    ENG_EASTERN_JEJU_CITY(LanguageCode.ENG, SpotRegion.EASTERN_JEJU_CITY, "Eastern Jeju City"),
+    ENG_WESTERN_SEOGWIPO_CITY(LanguageCode.ENG, SpotRegion.WESTERN_SEOGWIPO_CITY, "Western Seogwipo City"),
+    ENG_SEOGWIPO_CITY(LanguageCode.ENG, SpotRegion.SEOGWIPO_CITY, "Seogwipo City"),
+    ENG_EASTERN_SEOGWIPO_CITY(LanguageCode.ENG, SpotRegion.EASTERN_SEOGWIPO_CITY, "Eastern Seogwipo City"),
+    KOR_WESTERN_JEJU_CITY(LanguageCode.KOR, SpotRegion.WESTERN_JEJU_CITY, "제주시 서쪽"),
+    KOR_JEJU_CITY(LanguageCode.KOR, SpotRegion.JEJU_CITY, "제주시"),
+    KOR_EASTERN_JEJU_CITY(LanguageCode.KOR, SpotRegion.EASTERN_JEJU_CITY, "제주시 동쪽"),
+    KOR_WESTERN_SEOGWIPO_CITY(LanguageCode.KOR, SpotRegion.WESTERN_SEOGWIPO_CITY, "서귀포시 서쪽"),
+    KOR_SEOGWIPO_CITY(LanguageCode.KOR, SpotRegion.SEOGWIPO_CITY, "서귀포시"),
+    KOR_EASTERN_SEOGWIPO_CITY(LanguageCode.KOR, SpotRegion.EASTERN_SEOGWIPO_CITY, "서귀포시 동쪽"),
+    CHN_WESTERN_JEJU_CITY(LanguageCode.CHN, SpotRegion.WESTERN_JEJU_CITY, "濟州西部"),
+    CHN_JEJU_CITY(LanguageCode.CHN, SpotRegion.JEJU_CITY, "濟州市"),
+    CHN_EASTERN_JEJU_CITY(LanguageCode.CHN, SpotRegion.EASTERN_JEJU_CITY, "济州市东"),
+    CHN_WESTERN_SEOGWIPO_CITY(LanguageCode.CHN, SpotRegion.WESTERN_SEOGWIPO_CITY, "西归浦市西部"),
+    CHN_SEOGWIPO_CITY(LanguageCode.CHN, SpotRegion.SEOGWIPO_CITY, "西归浦市"),
+    CHN_EASTERN_SEOGWIPO_CITY(LanguageCode.CHN, SpotRegion.EASTERN_SEOGWIPO_CITY, "西归浦市东部"),
+    JPN_WESTERN_JEJU_CITY(LanguageCode.JPN, SpotRegion.WESTERN_JEJU_CITY, "済州西部"),
+    JPN_JEJU_CITY(LanguageCode.JPN, SpotRegion.JEJU_CITY, "済州市"),
+    JPN_EASTERN_JEJU_CITY(LanguageCode.JPN, SpotRegion.EASTERN_JEJU_CITY, "済州市東部"),
+    JPN_WESTERN_SEOGWIPO_CITY(LanguageCode.JPN, SpotRegion.WESTERN_SEOGWIPO_CITY, "西帰浦市西部"),
+    JPN_SEOGWIPO_CITY(LanguageCode.JPN, SpotRegion.SEOGWIPO_CITY, "西帰浦市"),
+    JPN_EASTERN_SEOGWIPO_CITY(LanguageCode.JPN, SpotRegion.EASTERN_SEOGWIPO_CITY, "西帰浦市東部");
+
+
+    private final LanguageCode languageCode;
+
+    private final SpotRegion spotRegion;
+
+    private final String name;
+
+    @JsonCreator
+    public static SpotTranslationRegion from(String value) {
+        for (SpotTranslationRegion spotTranslationRegion : SpotTranslationRegion.values()) {
+            if (spotTranslationRegion.name().equals(value)) {
+                return spotTranslationRegion;
+            }
+        }
+        throw new HalmangVisionException(INVALID_SPOT_TRANSLATION_REGION);
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRegion.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRegion.java
@@ -5,6 +5,7 @@ import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.gamgyul_code.halmang_vision.global.exception.HalmangVisionException;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -57,5 +58,12 @@ public enum SpotTranslationRegion {
     @JsonValue
     public String toValue() {
         return this.name();
+    }
+
+    public static SpotTranslationRegion from(LanguageCode languageCode, SpotRegion spotRegion) {
+        return Arrays.stream(values())
+                .filter(region -> region.languageCode == languageCode && region.spotRegion == spotRegion)
+                .findFirst()
+                .orElseThrow(() -> new HalmangVisionException(INVALID_SPOT_TRANSLATION_REGION));
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
@@ -12,4 +12,6 @@ public interface SpotTranslationRepository extends JpaRepository<SpotTranslation
     boolean existsBySpotIdAndLanguageCode(Long spotId, LanguageCode languageCode);
 
     List<SpotTranslation> findAllBySpot_SpotCategoryAndLanguageCode(SpotCategory spotCategory, LanguageCode languageCode);
+
+    List<SpotTranslation> findAllBySpot_SpotRegionAndLanguageCode(SpotRegion spotRegion, LanguageCode languageCode);
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
@@ -3,7 +3,9 @@ package com.gamgyul_code.halmang_vision.spot.dto;
 import com.gamgyul_code.halmang_vision.spot.domain.LanguageCode;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotRegion;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslation;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslationRegion;
 import com.gamgyul_code.halmang_vision.spot.domain.TravelerStatistics;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -26,6 +28,9 @@ public class SpotDto {
         @Schema(description = "관광지 카테고리", example = "halmang")
         private SpotCategory spotCategory;
 
+        @Schema(description = "관광지 지역", example = "JEJU_CITY")
+        private SpotRegion spotRegion;
+
         @Schema(description = "관광지 이미지 URL", example = "http://~~~.com/~~~.jpg")
         private String imgUrl;
 
@@ -42,6 +47,7 @@ public class SpotDto {
             return Spot.builder()
                     .name(name)
                     .spotCategory(spotCategory)
+                    .spotRegion(spotRegion)
                     .imgUrl(imgUrl)
                     .travelerStatistics(travelerStatistics)
                     .openingHours(openingHours)
@@ -61,6 +67,9 @@ public class SpotDto {
 
         @Schema(description = "언어 코드", example = "KOR")
         private LanguageCode languageCode;
+
+        @Schema(description = "번역 지역", example = "ENG_WESTERN_JEJU_CITY")
+        private SpotTranslationRegion spotTranslationRegion;
 
         @Schema(description = "요약", example = "역사 관련 장소")
         private String summary;
@@ -90,6 +99,7 @@ public class SpotDto {
             return SpotTranslation.builder()
                     .name(name)
                     .languageCode(languageCode)
+                    .spotTranslationRegion(spotTranslationRegion)
                     .summary(summary)
                     .address(address)
                     .fee(fee)

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
@@ -68,9 +68,6 @@ public class SpotDto {
         @Schema(description = "언어 코드", example = "KOR")
         private LanguageCode languageCode;
 
-        @Schema(description = "번역 지역", example = "ENG_WESTERN_JEJU_CITY")
-        private SpotTranslationRegion spotTranslationRegion;
-
         @Schema(description = "요약", example = "역사 관련 장소")
         private String summary;
 
@@ -95,7 +92,7 @@ public class SpotDto {
         @Schema(description = "관광지 간단 설명", example = "설문대할망이 태어난 장소")
         private String simpleExplanation;
 
-        public SpotTranslation toEntity(Spot spot) {
+        public SpotTranslation toEntity(Spot spot, SpotTranslationRegion spotTranslationRegion) {
             return SpotTranslation.builder()
                     .name(name)
                     .languageCode(languageCode)

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/presentation/SpotController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/presentation/SpotController.java
@@ -63,9 +63,9 @@ public class SpotController {
     }
 
     @GetMapping("/regions/{spotRegion}")
-    @Operation(summary = "지역별 관광지 목록 조회", description = "지역별 관광지를 조회한다. (WESTERN_JEJU_CITY, JEJU_CITY,"
-            + " EASTERN_JEJU_CITY, WESTERN_SEOGWIPO_CITY, SEOGWIPO_CITY, EASTERN_SEOGWIPO_CITY)")
-    public List<SimpleSpotTranslationResponse> findByRegion(@PathVariable SpotRegion spotRegion, @Parameter(hidden = true)
+    @Operation(summary = "지역별 관광지 목록 조회", description = "지역별 관광지를 조회한다. (western-jeju-city, jeju-city, eastern-jeju-city,"
+            + "western-seogwipo-city, seogwipo-city, eastern-seogwipo-city)")
+    public List<SimpleSpotTranslationResponse> findByRegion(@PathVariable String spotRegion, @Parameter(hidden = true)
                                                         @AuthPrincipal ApiMember apiMember) {
         return spotService.findAllSpotsByRegion(spotRegion, apiMember);
     }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/presentation/SpotController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/presentation/SpotController.java
@@ -4,6 +4,7 @@ import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
 import com.gamgyul_code.halmang_vision.spot.application.SpotService;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotRegion;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.CreateSpotTranslationRequest;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.CreateSpotRequest;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.SpotTranslationDetailResponse;
@@ -59,5 +60,13 @@ public class SpotController {
     @Operation(summary = "즐겨찾기한 관광지 목록 조회", description = "즐겨찾기한 관광지를 조회한다.")
     public List<SimpleSpotTranslationResponse> findByBookmarks(@Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         return spotService.findAllSpotsByBookmark(apiMember);
+    }
+
+    @GetMapping("/regions/{spotRegion}")
+    @Operation(summary = "지역별 관광지 목록 조회", description = "지역별 관광지를 조회한다. (WESTERN_JEJU_CITY, JEJU_CITY,"
+            + " EASTERN_JEJU_CITY, WESTERN_SEOGWIPO_CITY, SEOGWIPO_CITY, EASTERN_SEOGWIPO_CITY)")
+    public List<SimpleSpotTranslationResponse> findByRegion(@PathVariable SpotRegion spotRegion, @Parameter(hidden = true)
+                                                        @AuthPrincipal ApiMember apiMember) {
+        return spotService.findAllSpotsByRegion(spotRegion, apiMember);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 지역명을 담은 SpotRegion, SpotTranlslationRegion Enum 클래스 구현
- [x] 지역별 관광지 조회 API 구현

## 💡 자세한 설명
### postman 테스트 완료

```java
@AllArgsConstructor
@Getter
public enum SpotTranslationRegion {

    ENG_WESTERN_JEJU_CITY(LanguageCode.ENG, SpotRegion.WESTERN_JEJU_CITY, "Western Jeju City"),
    ENG_JEJU_CITY(LanguageCode.ENG, SpotRegion.JEJU_CITY, "Jeju City"),
    ENG_EASTERN_JEJU_CITY(LanguageCode.ENG, SpotRegion.EASTERN_JEJU_CITY, "Eastern Jeju City"),
    ENG_WESTERN_SEOGWIPO_CITY(LanguageCode.ENG, SpotRegion.WESTERN_SEOGWIPO_CITY, "Western Seogwipo City"),
    ENG_SEOGWIPO_CITY(LanguageCode.ENG, SpotRegion.SEOGWIPO_CITY, "Seogwipo City"),
    ENG_EASTERN_SEOGWIPO_CITY(LanguageCode.ENG, SpotRegion.EASTERN_SEOGWIPO_CITY, "Eastern Seogwipo City"),
    KOR_WESTERN_JEJU_CITY(LanguageCode.KOR, SpotRegion.WESTERN_JEJU_CITY, "제주시 서쪽"),
    KOR_JEJU_CITY(LanguageCode.KOR, SpotRegion.JEJU_CITY, "제주시"),
    KOR_EASTERN_JEJU_CITY(LanguageCode.KOR, SpotRegion.EASTERN_JEJU_CITY, "제주시 동쪽"),
    KOR_WESTERN_SEOGWIPO_CITY(LanguageCode.KOR, SpotRegion.WESTERN_SEOGWIPO_CITY, "서귀포시 서쪽"),
    KOR_SEOGWIPO_CITY(LanguageCode.KOR, SpotRegion.SEOGWIPO_CITY, "서귀포시"),
    KOR_EASTERN_SEOGWIPO_CITY(LanguageCode.KOR, SpotRegion.EASTERN_SEOGWIPO_CITY, "서귀포시 동쪽"),
    CHN_WESTERN_JEJU_CITY(LanguageCode.CHN, SpotRegion.WESTERN_JEJU_CITY, "濟州西部"),
    CHN_JEJU_CITY(LanguageCode.CHN, SpotRegion.JEJU_CITY, "濟州市"),
    CHN_EASTERN_JEJU_CITY(LanguageCode.CHN, SpotRegion.EASTERN_JEJU_CITY, "济州市东"),
    CHN_WESTERN_SEOGWIPO_CITY(LanguageCode.CHN, SpotRegion.WESTERN_SEOGWIPO_CITY, "西归浦市西部"),
    CHN_SEOGWIPO_CITY(LanguageCode.CHN, SpotRegion.SEOGWIPO_CITY, "西归浦市"),
    CHN_EASTERN_SEOGWIPO_CITY(LanguageCode.CHN, SpotRegion.EASTERN_SEOGWIPO_CITY, "西归浦市东部"),
    JPN_WESTERN_JEJU_CITY(LanguageCode.JPN, SpotRegion.WESTERN_JEJU_CITY, "済州西部"),
    JPN_JEJU_CITY(LanguageCode.JPN, SpotRegion.JEJU_CITY, "済州市"),
    JPN_EASTERN_JEJU_CITY(LanguageCode.JPN, SpotRegion.EASTERN_JEJU_CITY, "済州市東部"),
    JPN_WESTERN_SEOGWIPO_CITY(LanguageCode.JPN, SpotRegion.WESTERN_SEOGWIPO_CITY, "西帰浦市西部"),
    JPN_SEOGWIPO_CITY(LanguageCode.JPN, SpotRegion.SEOGWIPO_CITY, "西帰浦市"),
    JPN_EASTERN_SEOGWIPO_CITY(LanguageCode.JPN, SpotRegion.EASTERN_SEOGWIPO_CITY, "西帰浦市東部");


    private final LanguageCode languageCode;

    private final SpotRegion spotRegion;

    private final String name;
...
```
`SpotTranslationRegion` 은 지역 정보를 담은 Enum 클래스입니다. 각 언어별로 다른 지역명을 가지므로, `LanguageCode` 와 해당 `SpotTranslation` 이 가지고 있는 `Spot_SpotRegion` 을 기반으로 해당 `SpotTranslation` 의 지역을 저장합니다.

```java
@GetMapping("/regions/{spotRegion}")
    @Operation(summary = "지역별 관광지 목록 조회", description = "지역별 관광지를 조회한다. (western-jeju-city, jeju-city, eastern-jeju-city,"
            + "western-seogwipo-city, seogwipo-city, eastern-seogwipo-city)")
    public List<SimpleSpotTranslationResponse> findByRegion(@PathVariable String spotRegion, @Parameter(hidden = true)
                                                        @AuthPrincipal ApiMember apiMember) {
        return spotService.findAllSpotsByRegion(spotRegion, apiMember);
    }
```

해당 API는 RESTful하게 만들기 위해 `jeju-city` 와 같은 형태로 URI를 설정했습니다. 해당 경로변수 값은 서비스 로직에서 `-` 는 `_`로, 소문자는 대문자로 전환됩니다.
 
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #20
