### PR TITLE
관광지 카테고리 복수 보유 가능하도록 수정

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/application/SpotService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/application/SpotService.java
@@ -94,7 +94,7 @@ public class SpotService {
         LanguageCode languageCode = member.getLanguageCode();
 
         List<SpotTranslation> spotTranslations =
-                spotTranslationRepository.findAllBySpot_SpotCategoryAndLanguageCode(spotCategory, languageCode);
+                spotTranslationRepository.findAllBySpotCategoryAndLanguageCode(spotCategory, languageCode);
 
         return spotTranslations.stream()
                 .map(spotTranslation -> {

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/Spot.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/Spot.java
@@ -4,13 +4,16 @@ import com.gamgyul_code.halmang_vision.bookmark.domain.Bookmark;
 import com.gamgyul_code.halmang_vision.global.utils.BaseTimeEntity;
 import com.gamgyul_code.halmang_vision.route.domain.RouteSpot;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -42,7 +45,10 @@ public class Spot extends BaseTimeEntity {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
-    private SpotCategory spotCategory; // TODO : 리스트로 만들어야 함. 교집합 카테고리 가능
+    @ElementCollection
+    @CollectionTable(name = "spot_categories", joinColumns = @JoinColumn(name = "spot_id"))
+    @Column(name = "category")
+    private List<SpotCategory> spotCategory;
 
     @Enumerated(value = EnumType.STRING)
     @NotNull

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
@@ -3,6 +3,8 @@ package com.gamgyul_code.halmang_vision.spot.domain;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpotTranslationRepository extends JpaRepository<SpotTranslation, Long> {
     SpotTranslation findByName(String name);
@@ -11,7 +13,13 @@ public interface SpotTranslationRepository extends JpaRepository<SpotTranslation
 
     boolean existsBySpotIdAndLanguageCode(Long spotId, LanguageCode languageCode);
 
-    List<SpotTranslation> findAllBySpot_SpotCategoryAndLanguageCode(SpotCategory spotCategory, LanguageCode languageCode);
+    @Query("SELECT st FROM SpotTranslation st " +
+            "JOIN st.spot s " +
+            "WHERE :spotCategory IN elements(s.spotCategory) " +
+            "AND st.languageCode = :languageCode")
+    List<SpotTranslation> findAllBySpotCategoryAndLanguageCode(
+            @Param("spotCategory") SpotCategory spotCategory,
+            @Param("languageCode") LanguageCode languageCode);
 
     List<SpotTranslation> findAllBySpot_SpotRegionAndLanguageCode(SpotRegion spotRegion, LanguageCode languageCode);
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
@@ -8,6 +8,7 @@ import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslation;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslationRegion;
 import com.gamgyul_code.halmang_vision.spot.domain.TravelerStatistics;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,7 @@ public class SpotDto {
         private String name;
 
         @Schema(description = "관광지 카테고리", example = "halmang")
-        private SpotCategory spotCategory;
+        private List<SpotCategory> spotCategory;
 
         @Schema(description = "관광지 지역", example = "JEJU_CITY")
         private SpotRegion spotRegion;
@@ -123,7 +124,7 @@ public class SpotDto {
         private Long spotId;
 
         @Schema(description = "관광지 카테고리", example = "HISTORY")
-        private SpotCategory spotCategory;
+        private List<SpotCategory> spotCategory;
 
         @Schema(description = "관광지 이미지 URL", example = "http://~~~.com/~~~.jpg")
         private String imgUrl;


### PR DESCRIPTION
## 💡 작업 내용
- [x] `Spot`-`SpotCategory` 연관관계 매핑
- [x] 쿼리 작성 및 조회 기능 적용

## 💡 자세한 설명
### postman 테스트 완료

```java
Enumerated(value = EnumType.STRING)
    @NotNull
    @ElementCollection
    @CollectionTable(name = "spot_categories", joinColumns = @JoinColumn(name = "spot_id"))
    @Column(name = "category")
    private List<SpotCategory> spotCategory;
```

`Spot` 엔티티 내에 `@ElementCollection` 어노테이션을 사용해 연관관계를 맺어주었습니다.

`@ElementCollection` 은 JPA에서 엔티티가 아닌 값 타입(String, Enum...) 컬렉션을 매핑할 때 사용하는 어노테이션으로, List, Set 등의 컬렉션을 별도의 중간 테이블에 자동으로 매핑해주는 어노테이션입니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #22
