### PR TITLE
내 경로 생성 API 구현 완료

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     INVALID_SPOT_CATEGORY(BAD_REQUEST, "유효하지 않은 관광지 카테고리입니다."),
     INVALID_SPOT_REGION(BAD_REQUEST, "유효하지 않은 관광지 지역입니다."),
     INVALID_SPOT_TRANSLATION_REGION(BAD_REQUEST, "유효하지 않은 관광지 번역 지역입니다."),
+    INVALID_ROUTE_SPOT_SIZE(BAD_REQUEST, "경로에 포함된 관광지는 최소 2개, 최대 6개여야 합니다."),
+    INVALID_ROUT_SPOT_ID(BAD_REQUEST, "유효하지 않은 관광지 ID입니다."),
     // 401 Unauthorized
 
     // 403 Forbidden
@@ -33,7 +35,8 @@ public enum ErrorCode {
     ALREADY_EXIST_SPOT(CONFLICT, "이미 존재하는 관광지입니다."),
     ALREADY_EXIST_SPOT_TRANSLATION(CONFLICT, "이미 존재하는 관광지 번역입니다."),
     ALREADY_EXIST_SPOT_TRANSLATION_NAME(CONFLICT, "이미 존재하는 번역된 관광지 이름입니다."),
-    ALREADY_BOOKMARKED(CONFLICT, "이미 저장한 관광지입니다.");
+    ALREADY_BOOKMARKED(CONFLICT, "이미 저장한 관광지입니다."),
+    ALREADY_EXIST_ROUTE_NAME(CONFLICT, "이미 존재하는 경로 이름입니다.");
 
     // 500 Internal Server Error
 

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
@@ -1,0 +1,63 @@
+package com.gamgyul_code.halmang_vision.route.application;
+
+import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.ALREADY_EXIST_ROUTE_NAME;
+import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID_ROUTE_SPOT_SIZE;
+import static com.gamgyul_code.halmang_vision.global.exception.ErrorCode.INVALID_ROUT_SPOT_ID;
+
+import com.gamgyul_code.halmang_vision.global.exception.HalmangVisionException;
+import com.gamgyul_code.halmang_vision.member.domain.Member;
+import com.gamgyul_code.halmang_vision.member.domain.MemberRepository;
+import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
+import com.gamgyul_code.halmang_vision.route.domain.Route;
+import com.gamgyul_code.halmang_vision.route.domain.RouteRepository;
+import com.gamgyul_code.halmang_vision.route.domain.RouteSpot;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteRequest;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteSpotRequest;
+import com.gamgyul_code.halmang_vision.spot.domain.Spot;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RouteService {
+
+    private final MemberRepository memberRepository;
+    private final SpotRepository spotRepository;
+    private final RouteRepository routeRepository;
+
+    private static final int MINIMUM_ROUTE_SPOT_SIZE = 2;
+    private static final int MAXIMUM_ROUTE_SPOT_SIZE = 6;
+
+    public void createRoute(CreateRouteRequest createRouteRequest, ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+
+        String routeName = createRouteRequest.getRouteName();
+        if (routeRepository.existsByRouteNameAndMember(routeName, member)) {
+            throw new HalmangVisionException(ALREADY_EXIST_ROUTE_NAME);
+        }
+
+        List<Long> spotIds = createRouteRequest.getRouteSpots();
+        if (spotIds.size() < MINIMUM_ROUTE_SPOT_SIZE || spotIds.size() > MAXIMUM_ROUTE_SPOT_SIZE ) {
+            throw new HalmangVisionException(INVALID_ROUTE_SPOT_SIZE);
+        }
+
+        List<Spot> spots = spotRepository.findAllById(spotIds);
+        if (spots.size() != spotIds.size()) {
+            throw new HalmangVisionException(INVALID_ROUT_SPOT_ID);
+        }
+
+        Route route = createRouteRequest.toEntity(member);
+        routeRepository.save(route);
+
+        List<RouteSpot> routeSpots = spots.stream()
+                .map(spot -> CreateRouteSpotRequest.toEntity(spot, route))
+                .toList();
+
+        route.updateRoute(routeSpots);
+
+    }
+}

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/Route.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/Route.java
@@ -3,6 +3,7 @@ package com.gamgyul_code.halmang_vision.route.domain;
 import com.gamgyul_code.halmang_vision.global.utils.BaseTimeEntity;
 import com.gamgyul_code.halmang_vision.member.domain.Member;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,7 +31,8 @@ public class Route extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Size(max = 15)
+    @Size(min = 1, max = 15)
+    @Column(unique = true)
     private String routeName; // TODO : 해당 멤버 기준 중복 불가
 
     @ManyToOne
@@ -39,4 +41,8 @@ public class Route extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RouteSpot> routeSpots = new ArrayList<>();
+
+    public void updateRoute(List<RouteSpot> routeSpots) {
+        this.routeSpots = routeSpots;
+    }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteRepository.java
@@ -1,0 +1,9 @@
+package com.gamgyul_code.halmang_vision.route.domain;
+
+import com.gamgyul_code.halmang_vision.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteRepository extends JpaRepository<Route, Long> {
+
+    boolean existsByRouteNameAndMember(String routeName, Member member);
+}

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteSpot.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteSpot.java
@@ -30,6 +30,6 @@ public class RouteSpot extends BaseTimeEntity {
     private Spot spot;
 
     @ManyToOne
-    @JoinColumn(name = "route_id", nullable = false)
+    @JoinColumn(name = "route_id")
     private Route route;
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteSpotRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteSpotRepository.java
@@ -1,0 +1,6 @@
+package com.gamgyul_code.halmang_vision.route.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteSpotRepository extends JpaRepository<RouteSpot, Long> {
+}

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
@@ -1,0 +1,51 @@
+package com.gamgyul_code.halmang_vision.route.dto;
+
+import com.gamgyul_code.halmang_vision.member.domain.Member;
+import com.gamgyul_code.halmang_vision.route.domain.Route;
+import com.gamgyul_code.halmang_vision.route.domain.RouteSpot;
+import com.gamgyul_code.halmang_vision.spot.domain.Spot;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class RouteDto {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "경로 생성 요청")
+    public static class CreateRouteRequest {
+
+        @Schema(description = "경로 이름", example = "나의 경로")
+        private String routeName;
+
+        @Schema(description = "경로에 포함된 관광지 Id 리스트", example = "[1, 2, 3]")
+        private List<Long> routeSpots;
+
+        public Route toEntity(Member member) {
+            return Route.builder()
+                    .routeName(routeName)
+                    .member(member)
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "경로-루트 중간 엔티티 생성 요청 (프론트 사용 X)")
+    public static class CreateRouteSpotRequest {
+
+        @Schema(description = "경로에 추가할 관광지 ID", example = "1")
+        private Long spotId;
+
+        public static RouteSpot toEntity(Spot spot, Route route) {
+            return RouteSpot.builder()
+                    .spot(spot)
+                    .route(route)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
@@ -1,0 +1,29 @@
+package com.gamgyul_code.halmang_vision.route.presentation;
+
+import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
+import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
+import com.gamgyul_code.halmang_vision.route.application.RouteService;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/routes")
+@RequiredArgsConstructor
+@Tag(name = "route", description = "경로 API")
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @PostMapping
+    @Operation(summary = "내 경로 생성", description = "사용자에게 경로를 생성한다.")
+    public void createRoute(@RequestBody CreateRouteRequest createRouteRequest, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        routeService.createRoute(createRouteRequest, apiMember);
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] 내 경로 생성 API 구현

## 💡 자세한 설명
### postman 테스트 완료

```java
Route route = createRouteRequest.toEntity(member);
        routeRepository.save(route);

        List<RouteSpot> routeSpots = spots.stream()
                .map(spot -> CreateRouteSpotRequest.toEntity(spot, route))
                .toList();

        route.updateRoute(routeSpots);
```
Route-RouteSpot 테이블이 연결되어 있기 때문에, 

1. `List<RouteSpot> routeSpot` 필드는 null 인채로 Route 엔티티 생성
2. `routeSpot` 필드를 업데이트

와 같은 순서로 루트를 생성합니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
저장한 경로 조회, 삭제, 수정 API 구현
추천 경로 API 구현

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #26
