### PR TITLE
내 경로 조회, 수정, 삭제 API 구현 완료

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     NOT_FOUND_SPOT(NOT_FOUND, "해당 관광지를 찾을 수 없습니다."),
     NOT_FOUND_SPOT_TRANSLATION(NOT_FOUND, "해당 관광지 번역을 찾을 수 없습니다."),
     NOT_FOUND_BOOKMARK(NOT_FOUND, "해당 북마크를 찾을 수 없습니다."),
+    NOT_FOUND_ROUTE(NOT_FOUND, "해당 경로를 찾을 수 없습니다."),
 
     // 409 Conflict
     ALREADY_EXIST_SPOT(CONFLICT, "이미 존재하는 관광지입니다."),

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
@@ -13,6 +13,7 @@ import com.gamgyul_code.halmang_vision.route.domain.RouteRepository;
 import com.gamgyul_code.halmang_vision.route.domain.RouteSpot;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteRequest;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteSpotRequest;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.MyRouteResponse;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotRepository;
 import java.util.List;
@@ -58,6 +59,15 @@ public class RouteService {
                 .toList();
 
         route.updateRoute(routeSpots);
+    }
 
+    public List<MyRouteResponse> findAllMyRoutes(ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+
+        List<Route> routes = routeRepository.findAllByMember(member);
+
+        return routes.stream()
+                .map(MyRouteResponse::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
@@ -22,6 +22,7 @@ import com.gamgyul_code.halmang_vision.route.dto.RouteDto.RouteSpotResponse;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotRepository;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslation;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslationRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,7 @@ public class RouteService {
     private final MemberRepository memberRepository;
     private final SpotRepository spotRepository;
     private final RouteRepository routeRepository;
+    private final SpotTranslationRepository spotTranslationRepository;
 
     private static final int MINIMUM_ROUTE_SPOT_SIZE = 2;
     private static final int MAXIMUM_ROUTE_SPOT_SIZE = 6;
@@ -75,12 +77,7 @@ public class RouteService {
         Route route = routeRepository.findByIdAndMember(routeId, member)
                 .orElseThrow(() -> new HalmangVisionException(NOT_FOUND_ROUTE));
 
-        List<RouteSpot> routeSpots = route.getRouteSpots();
-        List<SpotTranslation> spotTranslations = routeSpots.stream()
-                .map(RouteSpot::getSpot)
-                .map(Spot::getTranslations)
-                .flatMap(List::stream)
-                .toList();
+        List<SpotTranslation> spotTranslations = spotTranslationRepository.findByRouteIdAndLanguageCode(routeId, member.getLanguageCode());
 
         List<RouteSpotResponse> routeSpotResponses = spotTranslations.stream()
                 .map(RouteSpotResponse::fromEntity)

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/application/RouteService.java
@@ -133,4 +133,12 @@ public class RouteService {
 
         route.updateRouteSpots(routeSpots);
     }
+
+    public void deleteRoute(Long routeId, ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        Route route = routeRepository.findByIdAndMember(routeId, member)
+                .orElseThrow(() -> new HalmangVisionException(NOT_FOUND_ROUTE));
+
+        routeRepository.delete(route);
+    }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/Route.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/Route.java
@@ -42,7 +42,16 @@ public class Route extends BaseTimeEntity {
     @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RouteSpot> routeSpots = new ArrayList<>();
 
-    public void updateRoute(List<RouteSpot> routeSpots) {
+    public void updateRouteName(String routeName) {
+        this.routeName = routeName;
+    }
+
+    public void initRouteSpots(List<RouteSpot> routeSpots) {
         this.routeSpots = routeSpots;
+    }
+
+    public void updateRouteSpots(List<RouteSpot> routeSpots) {
+        this.routeSpots.clear();
+        this.routeSpots.addAll(routeSpots);
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteRepository.java
@@ -1,9 +1,12 @@
 package com.gamgyul_code.halmang_vision.route.domain;
 
 import com.gamgyul_code.halmang_vision.member.domain.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
 
     boolean existsByRouteNameAndMember(String routeName, Member member);
+
+    List<Route> findAllByMember(Member member);
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/domain/RouteRepository.java
@@ -2,6 +2,7 @@ package com.gamgyul_code.halmang_vision.route.domain;
 
 import com.gamgyul_code.halmang_vision.member.domain.Member;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
@@ -9,4 +10,6 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     boolean existsByRouteNameAndMember(String routeName, Member member);
 
     List<Route> findAllByMember(Member member);
+
+    Optional<Route> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 public class RouteDto {
 
@@ -49,6 +50,30 @@ public class RouteDto {
                     .build();
         }
     }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "경로 이름 수정 요청")
+    public static class CreateRouteNameUpdateRequest {
+
+        @Schema(description = "경로 이름", example = "나의 경로")
+        private String routeName;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "경로 관광지 수정 요청")
+    public static class CreateRouteSpotUpdateRequest {
+
+        @Schema(description = "경로에 포함된 관광지 Id 리스트", example = "[1, 2, 3]")
+        private List<Long> routeSpots;
+
+    }
+
 
     @Data
     @Builder

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
@@ -4,6 +4,7 @@ import com.gamgyul_code.halmang_vision.member.domain.Member;
 import com.gamgyul_code.halmang_vision.route.domain.Route;
 import com.gamgyul_code.halmang_vision.route.domain.RouteSpot;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -69,6 +70,58 @@ public class RouteDto {
                     .id(route.getId())
                     .routeName(route.getRouteName())
                     .imgUrl(route.getRouteSpots().get(0).getSpot().getImgUrl())
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "내가 만든 경로 상세 조회")
+    public static class MyRouteDetailResponse {
+
+        @Schema(description = "경로 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "경로 이름", example = "나의 경로")
+        private String routeName;
+
+        @Schema(description = "루트 내 관광지 리스트", example = "[{spotId: 1, spotName: '성산일출봉', imgUrl: 'http://~~~.com/~~~.jpg'}, ...]")
+        private List<RouteSpotResponse> routeSpots;
+
+        public static MyRouteDetailResponse fromEntity(Route route, List<RouteSpotResponse> routeSpots) {
+            return MyRouteDetailResponse.builder()
+                    .id(route.getId())
+                    .routeName(route.getRouteName())
+                    .routeSpots(routeSpots)
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "경로 내 관광지 정보")
+    public static class RouteSpotResponse {
+
+        @Schema(description = "관광지 ID", example = "1")
+        private Long spotId;
+
+        @Schema(description = "관광지 번역 ID", example = "1")
+        private Long spotTranslationId;
+
+        @Schema(description = "관광지 이름", example = "성산일출봉")
+        private String spotName;
+
+        @Schema(description = "관광지 간단 설명", example = "설문대할망이 태어난 장소")
+        private String simpleExplanation;
+
+        public static RouteSpotResponse fromEntity(SpotTranslation spotTranslation) {
+            return RouteSpotResponse.builder()
+                    .spotId(spotTranslation.getSpot().getId())
+                    .spotTranslationId(spotTranslation.getId())
+                    .spotName(spotTranslation.getName())
+                    .simpleExplanation(spotTranslation.getSimpleExplanation())
                     .build();
         }
     }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/dto/RouteDto.java
@@ -48,4 +48,28 @@ public class RouteDto {
                     .build();
         }
     }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "내가 만든 경로 목록 조회")
+    public static class MyRouteResponse {
+
+        @Schema(description = "경로 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "경로 이름", example = "나의 경로")
+        private String routeName;
+
+        @Schema(description = "루트 내 첫 번째 관광지의 이미지 URL", example = "http://~~~.com/~~~.jpg")
+        private String imgUrl;
+
+        public static MyRouteResponse fromEntity(Route route) {
+            return MyRouteResponse.builder()
+                    .id(route.getId())
+                    .routeName(route.getRouteName())
+                    .imgUrl(route.getRouteSpots().get(0).getSpot().getImgUrl())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
@@ -4,10 +4,13 @@ import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
 import com.gamgyul_code.halmang_vision.route.application.RouteService;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteRequest;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.MyRouteResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +28,11 @@ public class RouteController {
     @Operation(summary = "내 경로 생성", description = "사용자에게 경로를 생성한다.")
     public void createRoute(@RequestBody CreateRouteRequest createRouteRequest, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         routeService.createRoute(createRouteRequest, apiMember);
+    }
+
+    @GetMapping
+    @Operation(summary = "내 경로 조회", description = "사용자가 만든 경로를 조회한다.")
+    public List<MyRouteResponse> findAllMyRoutes(@Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return routeService.findAllMyRoutes(apiMember);
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
@@ -3,8 +3,9 @@ package com.gamgyul_code.halmang_vision.route.presentation;
 import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
 import com.gamgyul_code.halmang_vision.route.application.RouteService;
-import com.gamgyul_code.halmang_vision.route.dto.RouteDto;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteNameUpdateRequest;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteRequest;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteSpotUpdateRequest;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.MyRouteDetailResponse;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.MyRouteResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,5 +45,17 @@ public class RouteController {
     @Operation(summary = "경로 상세 조회", description = "경로 상세 정보를 조회한다.")
     public MyRouteDetailResponse findMyRouteDetail(@PathVariable Long routeId, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         return routeService.findRouteDetail(routeId, apiMember);
+    }
+
+    @PutMapping("/{routeId}/name")
+    @Operation(summary = "경로 이름 수정", description = "경로를 수정한다.")
+    public void updateRouteName(@PathVariable Long routeId, @RequestBody CreateRouteNameUpdateRequest createRouteNameUpdateRequest, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        routeService.updateRouteName(routeId, createRouteNameUpdateRequest, apiMember);
+    }
+
+    @PutMapping("/{routeId}")
+    @Operation(summary = "경로 관광지 수정", description = "경로 관광지를 수정한다.")
+    public void updateRouteSpot(@PathVariable Long routeId, @RequestBody CreateRouteSpotUpdateRequest createRouteSpotUpdateRequest, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        routeService.updateRouteSpots(routeId, createRouteSpotUpdateRequest, apiMember);
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,20 +43,27 @@ public class RouteController {
     }
 
     @GetMapping("/{routeId}")
-    @Operation(summary = "경로 상세 조회", description = "경로 상세 정보를 조회한다.")
+    @Operation(summary = "내 경로 상세 조회", description = "경로 상세 정보를 조회한다.")
     public MyRouteDetailResponse findMyRouteDetail(@PathVariable Long routeId, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         return routeService.findRouteDetail(routeId, apiMember);
     }
 
     @PutMapping("/{routeId}/name")
-    @Operation(summary = "경로 이름 수정", description = "경로를 수정한다.")
+    @Operation(summary = "내 경로 이름 수정", description = "경로를 수정한다.")
     public void updateRouteName(@PathVariable Long routeId, @RequestBody CreateRouteNameUpdateRequest createRouteNameUpdateRequest, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         routeService.updateRouteName(routeId, createRouteNameUpdateRequest, apiMember);
     }
 
     @PutMapping("/{routeId}")
-    @Operation(summary = "경로 관광지 수정", description = "경로 관광지를 수정한다.")
+    @Operation(summary = "내 경로 관광지 수정", description = "경로 관광지를 수정한다.")
     public void updateRouteSpot(@PathVariable Long routeId, @RequestBody CreateRouteSpotUpdateRequest createRouteSpotUpdateRequest, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         routeService.updateRouteSpots(routeId, createRouteSpotUpdateRequest, apiMember);
     }
+
+    @DeleteMapping("/{routeId}")
+    @Operation(summary = "내 경로 삭제", description = "경로를 삭제한다.")
+    public void deleteRoute(@PathVariable Long routeId, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        routeService.deleteRoute(routeId, apiMember);
+    }
+
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/route/presentation/RouteController.java
@@ -3,7 +3,9 @@ package com.gamgyul_code.halmang_vision.route.presentation;
 import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
 import com.gamgyul_code.halmang_vision.route.application.RouteService;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.CreateRouteRequest;
+import com.gamgyul_code.halmang_vision.route.dto.RouteDto.MyRouteDetailResponse;
 import com.gamgyul_code.halmang_vision.route.dto.RouteDto.MyRouteResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +37,11 @@ public class RouteController {
     @Operation(summary = "내 경로 조회", description = "사용자가 만든 경로를 조회한다.")
     public List<MyRouteResponse> findAllMyRoutes(@Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         return routeService.findAllMyRoutes(apiMember);
+    }
+
+    @GetMapping("/{routeId}")
+    @Operation(summary = "경로 상세 조회", description = "경로 상세 정보를 조회한다.")
+    public MyRouteDetailResponse findMyRouteDetail(@PathVariable Long routeId, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return routeService.findRouteDetail(routeId, apiMember);
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
@@ -22,4 +22,11 @@ public interface SpotTranslationRepository extends JpaRepository<SpotTranslation
             @Param("languageCode") LanguageCode languageCode);
 
     List<SpotTranslation> findAllBySpot_SpotRegionAndLanguageCode(SpotRegion spotRegion, LanguageCode languageCode);
+
+    @Query("SELECT st FROM SpotTranslation st " +
+            "JOIN st.spot s " +
+            "JOIN RouteSpot rs ON rs.spot = s " +
+            "WHERE rs.route.id = :routeId AND st.languageCode = :languageCode")
+    List<SpotTranslation> findByRouteIdAndLanguageCode(@Param("routeId") Long routeId,
+                                                       @Param("languageCode") LanguageCode languageCode);
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 내 경로 조회, 수정, 삭제 API 구현
- [x] 경로 상세조회 API 구현

## 💡 자세한 설명
### postman 테스트 완료

경로 생성 시, Route-RouteSpot은 서로 참조 관계에 있습니다.
따라서 우선 `Route` 엔티티를 routeSpots 필드를 null인 상태로 생성 후, `initRouteSpots()` 메서드를 통해 생성한 `RouteSpot` 엔티티들을 할당시켜 줍니다.

```java
public void createRoute(CreateRouteRequest createRouteRequest, ApiMember apiMember) {
        Member member = apiMember.toMember(memberRepository);

        String routeName = createRouteRequest.getRouteName();
        List<Long> spotIds = createRouteRequest.getRouteSpots();
        List<Spot> spots = spotRepository.findAllById(spotIds);

        validateRouteName(routeName, member);
        validateRouteSpot(spotIds);

        Route route = createRouteRequest.toEntity(member);
        routeRepository.save(route);

        List<RouteSpot> routeSpots = spots.stream()
                .map(spot -> CreateRouteSpotRequest.toEntity(spot, route))
                .toList();

        route.initRouteSpots(routeSpots);
    }
```

또한 `Route`의 이름과 관광지 수정 처리는 해당 엔티티 내부에서 이뤄지게 만들었습니다. (캡슐화, 응집도, 객체 자율성 상승)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #26
