### PR TITLE
북마크시 카테고리 선택 기능 구현 완료

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/bookmark/application/BookmarkService.java
@@ -12,6 +12,7 @@ import com.gamgyul_code.halmang_vision.member.domain.Member;
 import com.gamgyul_code.halmang_vision.member.domain.MemberRepository;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,13 +29,13 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void createSpotBookmark(long spotId, ApiMember apiMember) {
+    public void createSpotBookmark(long spotId, SpotCategory spotCategory, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         Spot spot = findSpotById(spotId);
 
         validateBookmarkExists(member, spot, false);
 
-        bookmarkRepository.save(bookmarkGenerator.generate(spot, member));
+        bookmarkRepository.save(bookmarkGenerator.generate(spot, member, spotCategory));
     }
 
     @Transactional

--- a/src/main/java/com/gamgyul_code/halmang_vision/bookmark/domain/Bookmark.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/bookmark/domain/Bookmark.java
@@ -3,12 +3,16 @@ package com.gamgyul_code.halmang_vision.bookmark.domain;
 import com.gamgyul_code.halmang_vision.global.utils.BaseTimeEntity;
 import com.gamgyul_code.halmang_vision.member.domain.Member;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,6 +29,10 @@ public class Bookmark extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(value = EnumType.STRING)
+    @NotNull
+    SpotCategory spotCategory;
 
     @ManyToOne
     @JoinColumn(name = "spot_id")

--- a/src/main/java/com/gamgyul_code/halmang_vision/bookmark/domain/BookmarkGenerator.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/bookmark/domain/BookmarkGenerator.java
@@ -2,15 +2,17 @@ package com.gamgyul_code.halmang_vision.bookmark.domain;
 
 import com.gamgyul_code.halmang_vision.member.domain.Member;
 import com.gamgyul_code.halmang_vision.spot.domain.Spot;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BookmarkGenerator {
 
-    public Bookmark generate(Spot spot, Member member) {
+    public Bookmark generate(Spot spot, Member member, SpotCategory spotCategory) {
         return Bookmark.builder()
                 .member(member)
                 .spot(spot)
+                .spotCategory(spotCategory)
                 .build();
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/bookmark/presentation/BookmarkController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/bookmark/presentation/BookmarkController.java
@@ -3,6 +3,7 @@ package com.gamgyul_code.halmang_vision.bookmark.presentation;
 import com.gamgyul_code.halmang_vision.bookmark.application.BookmarkService;
 import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
+import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,9 +23,10 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
 
     @Operation(summary = "관광지 북마크 생성", description = "해당 회원에게 관광지 북마크를 생성한다.")
-    @PostMapping("/spots/{spotId}")
-    public void createSpotBookmark(@PathVariable Long spotId, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
-        bookmarkService.createSpotBookmark(spotId, apiMember);
+    @PostMapping("/spots/{spotId}/{spotCategory}")
+    public void createSpotBookmark(@PathVariable Long spotId, @PathVariable SpotCategory spotCategory,
+                                   @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        bookmarkService.createSpotBookmark(spotId, spotCategory, apiMember);
     }
 
     @Operation(summary = "관광지 북마크 삭제", description = "해당 회원에게 관광지 북마크를 삭제한다.")

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
@@ -168,6 +168,9 @@ public class SpotDto {
         @Schema(description = "북마크 여부", example = "true")
         private boolean bookmarked;
 
+        @Schema(description = "관광지 카테고리", example = "HISTORY, LOVE")
+        private List<SpotCategory> spotCategories;
+
         public static SpotTranslationDetailResponse fromEntity(SpotTranslation spotTranslation, boolean isBookmarked) {
             return SpotTranslationDetailResponse.builder()
                     .spotTranslationId(spotTranslation.getId())
@@ -187,6 +190,7 @@ public class SpotDto {
                     .topographyStory(spotTranslation.getTopographyStory())
                     .caution(spotTranslation.getCaution())
                     .bookmarked(isBookmarked)
+                    .spotCategories(spotTranslation.getSpot().getSpotCategory())
                     .build();
         }
     }
@@ -215,6 +219,9 @@ public class SpotDto {
             @Schema(description = "북마크 여부", example = "true")
             private boolean bookmarked;
 
+            @Schema(description = "관광지 카테고리", example = "HISTORY, LOVE")
+            private List<SpotCategory> spotCategories;
+
             public static SimpleSpotTranslationResponse fromEntity(SpotTranslation spotTranslation, boolean isBookmarked) {
                 return SimpleSpotTranslationResponse.builder()
                         .spotTranslationId(spotTranslation.getId())
@@ -223,6 +230,7 @@ public class SpotDto {
                         .imgUrl(spotTranslation.getSpot().getImgUrl())
                         .simpleExplanation(spotTranslation.getSimpleExplanation())
                         .bookmarked(isBookmarked)
+                        .spotCategories(spotTranslation.getSpot().getSpotCategory())
                         .build();
             }
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] `Bookmark` 엔티티 내에 `SpotCategory` 필드 추가
- [x] `SpotDto` 에서 북마크 추가 시 카테고리 선택을 위한 `List<SpotCategory>` 타입 필드 반환
- [x] 북마크 생성 API에서 `SpotCategory` 를 `PathVariable` 로 받도록 수정

## 💡 자세한 설명
<img width="646" alt="스크린샷 2024-11-21 오후 6 47 59" src="https://github.com/user-attachments/assets/9467ba56-f72d-4632-8ad8-395d9a303530">

북마크 시, 해당 `Spot` 이 2개 이상의 카테고리를 가지고 있는 경우, 사용자가 어떤 카테고리로 저장할지를 선택할 수 있습니다.

따라서, `Bookmark` 엔티티 내에 `SpotCategory` 필드를 추가하고, `SpotDto` 에서 해당 관광지가 어떤 카테고리에 속해있는지를 반환, 클라이언트에서 해당 값들을 유저에게 팝업으로 전달하고, 사용자가 고르는 값을 `PathVariable` 로 서버에게 전달하도록 구현했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #29
