### PR TITLE
관광지 엔티티에 위도, 경도 필드 추가, 설화 기반 관광지 필터링 기능 구현 완료

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/application/SpotService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/application/SpotService.java
@@ -22,6 +22,7 @@ import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslationRegion;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotTranslationRepository;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.CreateSpotRequest;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.CreateSpotTranslationRequest;
+import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.MainScreenFilteredSpotTranslationResponse;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.SpotTranslationDetailResponse;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.SimpleSpotTranslationResponse;
 import java.util.List;
@@ -140,6 +141,24 @@ public class SpotService {
                     long memberId = member.getId();
                     boolean isBookmarked = bookmarkSpotRepository.existsBookmarkByMemberIdAndSpotId(memberId, spotTranslation.getId());
                     return SimpleSpotTranslationResponse.fromEntity(spotTranslation, isBookmarked);
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MainScreenFilteredSpotTranslationResponse> findAllSpotsByMainScreenFilter(SpotCategory spotCategory,
+                                                                                          ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        LanguageCode languageCode = member.getLanguageCode();
+
+        List<SpotTranslation> spotTranslations =
+                spotTranslationRepository.findAllBySpot_SpotCategoryAndLanguageCode(spotCategory, languageCode);
+
+        return spotTranslations.stream()
+                .map(spotTranslation -> {
+                    long memberId = member.getId();
+                    boolean isBookmarked = bookmarkSpotRepository.existsBookmarkByMemberIdAndSpotId(memberId, spotTranslation.getId());
+                    return MainScreenFilteredSpotTranslationResponse.fromEntity(spotTranslation, isBookmarked);
                 })
                 .toList();
     }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/Spot.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/Spot.java
@@ -66,6 +66,10 @@ public class Spot extends BaseTimeEntity {
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$")
     private String phoneNumber;
 
+    private Double latitude;
+
+    private Double longitude;
+
     @OneToMany(mappedBy = "spot", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SpotTranslation> translations = new ArrayList<>();
 

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/domain/SpotTranslationRepository.java
@@ -36,4 +36,6 @@ public interface SpotTranslationRepository extends JpaRepository<SpotTranslation
             "WHERE rs.recommendRoute.id= :recommendRouteId AND st.languageCode = :languageCode")
     List<SpotTranslation> findByRecommendRouteIdAndLanguageCode(@Param("recommendRouteId") Long recommendRouteId,
                                                                 @Param("languageCode") LanguageCode languageCode);
+
+    List<SpotTranslation> findAllBySpot_SpotCategoryAndLanguageCode(SpotCategory spotCategory, LanguageCode languageCode);
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/dto/SpotDto.java
@@ -44,6 +44,12 @@ public class SpotDto {
         @Schema(description = "관광지 전화번호", example = "064-783-0959")
         private String phoneNumber;
 
+        @Schema(description = "위도", example = "33.458")
+        private double latitude;
+
+        @Schema(description = "경도", example = "126.942")
+        private double longitude;
+
         public Spot toEntity() {
             return Spot.builder()
                     .name(name)
@@ -53,6 +59,8 @@ public class SpotDto {
                     .travelerStatistics(travelerStatistics)
                     .openingHours(openingHours)
                     .phoneNumber(phoneNumber)
+                    .latitude(latitude)
+                    .longitude(longitude)
                     .build();
         }
     }
@@ -233,5 +241,54 @@ public class SpotDto {
                         .spotCategories(spotTranslation.getSpot().getSpotCategory())
                         .build();
             }
+    }
+
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "메인 필터링 관광지 정보(번역) 응답")
+    public static class MainScreenFilteredSpotTranslationResponse {
+
+        @Schema(description = "관광지 번역 id", example = "1")
+        private Long spotTranslationId;
+
+        @Schema(description = "관광지 id(번역 이전)", example = "1")
+        private Long spotId;
+
+        @Schema(description = "관광지 이름", example = "성산일출봉")
+        private String name;
+
+        @Schema(description = "관광지 이미지 URL", example = "http://~~~.com/~~~.jpg")
+        private String imgUrl;
+
+        @Schema(description = "연간 관광객 정보", example = "HIGH")
+        private TravelerStatistics travelerStatistics;
+
+        @Schema(description = "북마크 여부", example = "true")
+        private boolean bookmarked;
+
+        @Schema(description = "관광지 카테고리", example = "HISTORY, LOVE")
+        private List<SpotCategory> spotCategories;
+
+        @Schema(description = "위도", example = "33.458")
+        private double latitude;
+
+        @Schema(description = "경도", example = "126.942")
+        private double longitude;
+
+        public static MainScreenFilteredSpotTranslationResponse fromEntity(SpotTranslation spotTranslation, boolean isBookmarked) {
+            return MainScreenFilteredSpotTranslationResponse.builder()
+                    .spotTranslationId(spotTranslation.getId())
+                    .spotId(spotTranslation.getSpot().getId())
+                    .name(spotTranslation.getName())
+                    .imgUrl(spotTranslation.getSpot().getImgUrl())
+                    .travelerStatistics(spotTranslation.getSpot().getTravelerStatistics())
+                    .bookmarked(isBookmarked)
+                    .spotCategories(spotTranslation.getSpot().getSpotCategory())
+                    .latitude(spotTranslation.getSpot().getLatitude())
+                    .longitude(spotTranslation.getSpot().getLongitude())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/spot/presentation/SpotController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/spot/presentation/SpotController.java
@@ -4,9 +4,9 @@ import com.gamgyul_code.halmang_vision.global.utils.AuthPrincipal;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
 import com.gamgyul_code.halmang_vision.spot.application.SpotService;
 import com.gamgyul_code.halmang_vision.spot.domain.SpotCategory;
-import com.gamgyul_code.halmang_vision.spot.domain.SpotRegion;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.CreateSpotTranslationRequest;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.CreateSpotRequest;
+import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.MainScreenFilteredSpotTranslationResponse;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.SpotTranslationDetailResponse;
 import com.gamgyul_code.halmang_vision.spot.dto.SpotDto.SimpleSpotTranslationResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -68,5 +68,12 @@ public class SpotController {
     public List<SimpleSpotTranslationResponse> findByRegion(@PathVariable String spotRegion, @Parameter(hidden = true)
                                                         @AuthPrincipal ApiMember apiMember) {
         return spotService.findAllSpotsByRegion(spotRegion, apiMember);
+    }
+
+    @GetMapping("/filters/{spotCategory}")
+    @Operation(summary = "메인 화면 필터링", description = "주어진 관광지 카테고리에 따라 관광지를 필터링해 조회한다. (halmang, love, history, myth)")
+    public List<MainScreenFilteredSpotTranslationResponse> findByMainFilter(@PathVariable SpotCategory spotCategory, @Parameter(hidden = true)
+                                                        @AuthPrincipal ApiMember apiMember) {
+        return spotService.findAllSpotsByMainScreenFilter(spotCategory, apiMember);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] `Spot` 엔티티에 위도, 경도 필드 추가
- [x] 설화 기반 관광지 필터링 기능 구현 완료

## 💡 자세한 설명
### postman 테스트 완료

### `Spot` 엔티티에 위도, 경도 필드 추가
네이버 지도 API 활용을 위한 위도, 경도 필드를 추가했습니다.

### 설화 기반 관광지 필터링 기능 구현 완료
`/spots/filters/{spotCategory}` 를 통해 입력받는 관광지 카테고리별로 필터링한 모든 관광지를 조회하도록 설정했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #31
