### PR TITLE
엑세스 토큰 재발급(reIssue) API 구현 완료

### DIFF
--- a/src/main/java/com/gamgyul_code/halmang_vision/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/global/jwt/JwtTokenProvider.java
@@ -77,6 +77,7 @@ public class JwtTokenProvider {
         Cookie cookie = new Cookie(cookieName, refreshToken);
         cookie.setHttpOnly(true);
         //cookie.setSecure(true);
+        cookie.setDomain("localhost:3000");
         cookie.setPath("/");
         cookie.setMaxAge(60 * 60 * 24); // accessToken 유효
         return cookie;
@@ -87,6 +88,7 @@ public class JwtTokenProvider {
         Cookie cookie = new Cookie(cookieName, accessToken);
         cookie.setHttpOnly(true);
         //cookie.setSecure(true); TODO : HTTPS 적용 시 적용 가능
+        cookie.setDomain("localhost:3000");
         cookie.setPath("/");
         cookie.setMaxAge(60 * 60 * 24);
         return cookie;

--- a/src/main/java/com/gamgyul_code/halmang_vision/member/application/MemberService.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.gamgyul_code.halmang_vision.member.application;
 
+import com.gamgyul_code.halmang_vision.global.jwt.JwtTokenProvider;
 import com.gamgyul_code.halmang_vision.member.domain.Member;
 import com.gamgyul_code.halmang_vision.member.domain.MemberRepository;
 import com.gamgyul_code.halmang_vision.member.dto.ApiMember;
@@ -22,6 +23,7 @@ import org.springframework.web.servlet.view.RedirectView;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public RedirectView logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
@@ -50,5 +52,20 @@ public class MemberService {
             cookie.setMaxAge(0);
             response.addCookie(cookie);
         }
+    }
+
+    public String reissueAccessToken(HttpServletRequest request, ApiMember apiMember) {
+        long memberId = apiMember.toMember(memberRepository).getId();
+
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            String name = cookie.getName();
+            if (name.equals("refreshToken")) {
+                String refreshToken = cookie.getValue();
+                jwtTokenProvider.validateToken(refreshToken);
+                return jwtTokenProvider.reissueAccessToken(refreshToken, memberId);
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/gamgyul_code/halmang_vision/member/presentation/MemberController.java
+++ b/src/main/java/com/gamgyul_code/halmang_vision/member/presentation/MemberController.java
@@ -71,4 +71,10 @@ public class MemberController {
     public void updateLanguageCode(@PathVariable String code, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         memberService.updateLanguageCode(code, apiMember);
     }
+
+    @GetMapping("/reissue")
+    @Operation(summary = "액세스 토큰 재발급", description = "액세스 토큰을 재발급합니다.")
+    public String reissueAccessToken(HttpServletRequest request, @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return memberService.reissueAccessToken(request, apiMember);
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 엑세스 토큰 재발급 API 구현
- [x] 쿠키 반환 도메인 프론트 local로 설정

## 💡 자세한 설명
엑세스 토큰 재발급 API를 구현했습니다.
쿠키에 refreshToken을 담아 해당 API를 호출하면, 엑세스 토큰을 재발급해 줍니다.

또한 쿠키가 반환되는 도메인을 `localhost:3000` 으로 설정했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #41
